### PR TITLE
Removing onRecyclerDidMount from the otherProps to prevent warning me…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-scroll-recycler",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A ReactJS wrapper component to limit DOM elements rendered",
   "main": "dist/index.js",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ class DomScrollRecycler extends Component {
       calculatePositionalValues,
       className,
       isTable,
+      onRecyclerDidMount,
       ...otherProps
     } = this.props;
 


### PR DESCRIPTION
…ssage

Removing `onRecyclerDidMount` from the `otherProps` preventing annoying warning message.